### PR TITLE
Preserve user-uploaded profile photos during Firebase user updates fo…

### DIFF
--- a/api/auth/kakao.js
+++ b/api/auth/kakao.js
@@ -81,9 +81,17 @@ export default async function handler(req, res) {
     const firebaseUid = `kakao:${kakaoUid}`;
 
     try {
+      const existingUser = await admin.auth().getUser(firebaseUid);
+
+      // Preserve a user-uploaded profile photo (Firebase Storage URL).
+      // Only overwrite photoURL if the user hasn't set a custom one.
+      const existingPhoto = existingUser.photoURL || '';
+      const hasCustomPhoto = existingPhoto.includes('firebasestorage.googleapis.com')
+        || existingPhoto.includes('firebasestorage.app');
+
       await admin.auth().updateUser(firebaseUid, {
         ...(displayName && { displayName }),
-        ...(photoURL && { photoURL }),
+        ...(!hasCustomPhoto && photoURL && { photoURL }),
         ...(email && { email }),
       });
     } catch (e) {

--- a/api/auth/line.js
+++ b/api/auth/line.js
@@ -91,9 +91,17 @@ export default async function handler(req, res) {
     const firebaseUid = `line:${lineUserId}`;
 
     try {
+      const existingUser = await admin.auth().getUser(firebaseUid);
+
+      // Preserve a user-uploaded profile photo (Firebase Storage URL).
+      // Only overwrite photoURL if the user hasn't set a custom one.
+      const existingPhoto = existingUser.photoURL || '';
+      const hasCustomPhoto = existingPhoto.includes('firebasestorage.googleapis.com')
+        || existingPhoto.includes('firebasestorage.app');
+
       await admin.auth().updateUser(firebaseUid, {
         ...(displayName && { displayName }),
-        ...(photoURL && { photoURL }),
+        ...(!hasCustomPhoto && photoURL && { photoURL }),
         ...(email && { email }),
       });
     } catch (e) {


### PR DESCRIPTION
This pull request improves how user profile photos are managed during authentication for both Kakao and LINE providers. The main change ensures that if a user has uploaded a custom profile photo (stored in Firebase Storage), it will not be overwritten by the provider's default photo during future logins.

User profile photo preservation:

* In `api/auth/kakao.js`, before updating the user profile, the code now checks if the existing `photoURL` is a Firebase Storage URL. If so, the photo is preserved and not overwritten by the Kakao profile photo.
* In `api/auth/line.js`, a similar check is added to preserve a user-uploaded photo if it exists, preventing the LINE profile photo from overwriting it.…r Kakao and Line authentication